### PR TITLE
Modified to account for padding on inputs

### DIFF
--- a/jquery.expandable.js
+++ b/jquery.expandable.js
@@ -20,7 +20,7 @@
 			duration: 300
     }, options );
 
-		var width = this.width();
+		var width = this.outerWidth();
 
 		this.on("focus", function(){
 			// $(this).css({width: settings.width});


### PR DESCRIPTION
I replaced the original width calculation (this.width) to use this.outerWidth to account for padding on inputs.
